### PR TITLE
Fix venv path and provider timeout

### DIFF
--- a/Tcript/app.py
+++ b/Tcript/app.py
@@ -16,7 +16,7 @@ RPC_URL = os.getenv("RPC_URL")
 CONTRACT_ADDRESS = os.getenv("CONTRACT_ADDRESS")
 
 app = Flask(__name__)
-w3 = Web3(Web3.HTTPProvider(RPC_URL))
+w3 = Web3(Web3.HTTPProvider(RPC_URL, request_kwargs={"timeout": 5}))
 
 # Load the ABI relative to this file so running from other directories works
 ABI_PATH = os.path.join(os.path.dirname(__file__), "abi.json")

--- a/venv/bin/activate
+++ b/venv/bin/activate
@@ -39,10 +39,10 @@ deactivate nondestructive
 if [ "${OSTYPE:-}" = "cygwin" ] || [ "${OSTYPE:-}" = "msys" ] ; then
     # transform D:\path\to\venv to /d/path/to/venv on MSYS
     # and to /cygdrive/d/path/to/venv on Cygwin
-    export VIRTUAL_ENV=$(cygpath /home/tahatxt/transcript_project/venv)
+    export VIRTUAL_ENV=$(cygpath /workspace/Transcript-Token/venv)
 else
     # use the path as-is
-    export VIRTUAL_ENV=/home/tahatxt/transcript_project/venv
+    export VIRTUAL_ENV=/workspace/Transcript-Token/venv
 fi
 
 _OLD_VIRTUAL_PATH="$PATH"


### PR DESCRIPTION
## Summary
- ensure the `activate` script points at the repository's virtualenv
- give Web3 HTTPProvider a short timeout so failed RPC calls return quickly

## Testing
- `python Tcript/app.py 2>&1 | head -n 20`