### PR TITLE
Add environment-based contract address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ venv/
 
 # Environment variables
 .env
-necessities.env
+# do not ignore necessities.env so the contract address can be shared
 
 # IDE/editor settings
 .vscode/

--- a/necessities.env
+++ b/necessities.env
@@ -1,0 +1,6 @@
+# Required environment variables for TranscriptToken project
+# Add your Sepolia RPC URL and wallet details
+RPC_URL=
+CONTRACT_ADDRESS=0x0000000000000000000000000000000000000000
+PRIVATE_KEY=
+WALLET_ADDRESS=

--- a/subgraph/abis/TranscriptToken.json
+++ b/subgraph/abis/TranscriptToken.json
@@ -1,0 +1,12 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {"indexed": true, "internalType": "address", "name": "from", "type": "address"},
+      {"indexed": true, "internalType": "address", "name": "to", "type": "address"},
+      {"indexed": false, "internalType": "uint256", "name": "value", "type": "uint256"}
+    ],
+    "name": "Transfer",
+    "type": "event"
+  }
+]

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -1,0 +1,16 @@
+type Holder @entity {
+  id: ID!
+  balance: BigInt!
+}
+
+type Token @entity {
+  id: ID!
+  holderCount: Int!
+}
+
+type DailyStat @entity {
+  id: ID!
+  date: Int!
+  volume: BigInt!
+  holderCount: Int!
+}

--- a/subgraph/src/mapping.ts
+++ b/subgraph/src/mapping.ts
@@ -1,0 +1,59 @@
+import { Address, BigInt } from "@graphprotocol/graph-ts"
+import { Transfer } from "../generated/TranscriptToken/TranscriptToken"
+import { Holder, Token, DailyStat } from "../generated/schema"
+
+let ZERO_ADDRESS = Address.fromString("0x0000000000000000000000000000000000000000")
+
+export function handleTransfer(event: Transfer): void {
+  let token = Token.load("TCRIPT")
+  if (token == null) {
+    token = new Token("TCRIPT")
+    token.holderCount = 0
+  }
+
+  // FROM holder
+  if (event.params.from != ZERO_ADDRESS) {
+    let holder = Holder.load(event.params.from.toHex())
+    if (holder == null) {
+      holder = new Holder(event.params.from.toHex())
+      holder.balance = BigInt.zero()
+    }
+    let before = holder.balance
+    holder.balance = holder.balance.minus(event.params.value)
+    holder.save()
+    if (before.gt(BigInt.zero()) && holder.balance.equals(BigInt.zero())) {
+      token.holderCount = token.holderCount - 1
+    }
+  }
+
+  // TO holder
+  if (event.params.to != ZERO_ADDRESS) {
+    let holder = Holder.load(event.params.to.toHex())
+    if (holder == null) {
+      holder = new Holder(event.params.to.toHex())
+      holder.balance = BigInt.zero()
+    }
+    let before = holder.balance
+    holder.balance = holder.balance.plus(event.params.value)
+    holder.save()
+    if (before.equals(BigInt.zero()) && holder.balance.gt(BigInt.zero())) {
+      token.holderCount = token.holderCount + 1
+    }
+  }
+
+  token.save()
+
+  // Daily stats
+  let day = event.block.timestamp.toI32() / 86400
+  let id = day.toString()
+  let stat = DailyStat.load(id)
+  if (stat == null) {
+    stat = new DailyStat(id)
+    stat.date = day * 86400
+    stat.volume = BigInt.zero()
+    stat.holderCount = token.holderCount
+  }
+  stat.volume = stat.volume.plus(event.params.value)
+  stat.holderCount = token.holderCount
+  stat.save()
+}

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -1,0 +1,27 @@
+specVersion: 0.0.5
+schema:
+  file: ./schema.graphql
+
+dataSources:
+  - kind: ethereum
+    name: TranscriptToken
+    network: sepolia
+    source:
+      address: "{{ env.CONTRACT_ADDRESS }}"
+      abi: TranscriptToken
+      startBlock: 0
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - Holder
+        - Token
+        - DailyStat
+      abis:
+        - name: TranscriptToken
+          file: ./abis/TranscriptToken.json
+      eventHandlers:
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleTransfer
+      file: ./src/mapping.ts


### PR DESCRIPTION
## Summary
- load the contract address from `necessities.env`
- stop ignoring `necessities.env` in `.gitignore`
- include a template `necessities.env` file with placeholders

## Testing
- No tests provided in repo. `npx graph codegen subgraph` fails because packages cannot be downloaded in this environment.