### PR TITLE
Style fund page and keep footer at bottom

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -9,6 +9,13 @@ body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     color: #111;
     line-height: 1.5;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+main {
+    flex: 1;
 }
 
 a {
@@ -166,4 +173,15 @@ footer {
     display: block;
     margin-bottom: 0.3rem;
     color: inherit;
+}
+
+/* Fund page */
+.fund-page {
+    text-align: center;
+    margin-top: 3rem;
+}
+
+.fund-page button,
+.fund-page input {
+    margin: 0.5rem;
 }

--- a/templates/fund.html
+++ b/templates/fund.html
@@ -3,15 +3,13 @@
 {% block title %}Fund{% endblock %}
 
 {% block main %}
-
-    <body>
+    <div class="container fund-page">
         <button id="connectButton">Connect</button>
         <button id="balanceButton">Get Balance</button>
         <label for="ethAmount">ETH Amount</label>
-        <input id="ethAmount" placeholder="0.1"/>
-        <button type="Button" id="fundButton">Fund</button>
-    </body>
+        <input id="ethAmount" placeholder="0.1" />
+        <button type="button" id="fundButton">Fund</button>
+    </div>
 
-    <script src="../static/index-ts.ts" type="module"></script>
-
+    <script src="{{ url_for('static', filename='index-ts.ts') }}" type="module"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- center fund page content
- keep footer at the bottom of the screen using flexbox
- add minor styling for fund page

## Testing
- `python -m py_compile app.py`
- `npm test` *(fails: Missing script)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685090efada0832bae7f53dd579b8560