### PR TITLE
Update fund page button styles

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -166,6 +166,19 @@ a.logo:active {
     transition: opacity 0.2s;
 }
 
+/* Position the connect button at the top center */
+#connectButton {
+    flex-basis: 100%;
+    max-width: fit-content;
+    margin: 0 auto 1rem;
+}
+
+/* Style the fund button */
+#fundButton {
+    background: blue;
+    color: white;
+}
+
 .fund-page button:hover {
     opacity: 0.8;
 }


### PR DESCRIPTION
## Summary
- adjust the connect button to appear centered on its own row
- turn the Fund button blue with white text
- restore the connect button's original width

## Testing
- `npm test` *(fails: Missing script)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6850a006d944832b831c29eed5d14f1e